### PR TITLE
Remove debug print

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub struct SqliteConnectionManager {
 }
 
 impl SqliteConnectionManager {
-    
+
     pub fn new(database: &str)-> Result<SqliteConnectionManager, SqliteError>{
         match database{
             ":memory:" => {
@@ -65,7 +65,6 @@ impl r2d2::ManageConnection for SqliteConnectionManager {
             Ok(SqliteConnection::open_in_memory().unwrap())
         }
         else if self.path.is_some(){
-            println!("path: {:?}", self.path);
             Ok(SqliteConnection::open(&Path::new(self.path.as_ref().unwrap())).unwrap())
         }
         else{


### PR DESCRIPTION
Hey!

Thanks for your lib, and you did really great by updating it as soon as rusqlite 0.4.0 was released!

I just think you forgot to remove some kind of debug print, while using your updated crate, I've noticed that lines appeared on my console output, I fixed this with this commit (as well as my editor removed some trailing whitespaces).

Would be nice if you could merge this small PR o/