### PR TITLE
Error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.0.4"
 dependencies = [
  "r2d2 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -57,6 +58,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +74,14 @@ dependencies = [
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsqlite3-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ path = "tests/test.rs"
 [dependencies]
 r2d2 = "0.6.1"
 rusqlite = "0.6.0"
+
+[dev-dependencies]
+tempdir = "^0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use std::error::Error as _StdError;
 use std::fmt;
 
 use rusqlite::SqliteError;
-use rusqlite::SqliteConnection;
+use rusqlite::Connection;
 
 use std::path::Path;
 
@@ -57,26 +57,26 @@ impl SqliteConnectionManager {
 }
 
 impl r2d2::ManageConnection for SqliteConnectionManager {
-    type Connection = SqliteConnection;
+    type Connection = Connection;
     type Error = Error;
 
-    fn connect(&self) -> Result<SqliteConnection, Error> {
-        if self.in_memory{
-            Ok(SqliteConnection::open_in_memory().unwrap())
+    fn connect(&self) -> Result<Connection, Error> {
+        if self.in_memory {
+            Ok(Connection::open_in_memory().unwrap())
         }
-        else if self.path.is_some(){
-            Ok(SqliteConnection::open(&Path::new(self.path.as_ref().unwrap())).unwrap())
+        else if self.path.is_some() {
+            Ok(Connection::open(&Path::new(self.path.as_ref().unwrap())).unwrap())
         }
-        else{
+        else {
             unreachable!()
         }
     }
 
-    fn is_valid(&self, conn: &mut SqliteConnection) -> Result<(), Error> {
+    fn is_valid(&self, conn: &mut Connection) -> Result<(), Error> {
         conn.execute_batch("").map_err(Error::Connect)
     }
 
-    fn has_broken(&self, conn: &mut SqliteConnection) -> bool {
+    fn has_broken(&self, conn: &mut Connection) -> bool {
         false
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,10 +1,15 @@
 extern crate rusqlite;
 extern crate r2d2;
 extern crate r2d2_sqlite;
+extern crate tempdir;
 
 use std::sync::Arc;
 use std::sync::mpsc;
 use std::thread;
+use std::time::Duration;
+
+use r2d2::ManageConnection;
+use tempdir::TempDir;
 
 use r2d2_sqlite::SqliteConnectionManager;
 
@@ -77,4 +82,13 @@ fn test_is_valid() {
     let pool = r2d2::Pool::new(config, manager).unwrap();
 
     pool.get().unwrap();
+}
+
+#[test]
+fn test_error_handling() {
+    //! We specify a directory as a database. This is bound to fail.
+    let dir = TempDir::new("r2d2-sqlite").expect("Could not create temporary directory");
+    let dirpath = dir.path().to_str().unwrap();
+    let manager = SqliteConnectionManager::new(dirpath).unwrap();
+    assert!(manager.connect().is_err());
 }


### PR DESCRIPTION
You have a lot of `.unwrap()` in your code, that should probably all be removed. Otherwise panics will occur.

I did a first step and removed the unwraps in `SqliteConnectionManager::new`.

By implementing `From<rusqlite::Error> for Error` you can automatically cast rusqlite errors to your own error type by using `try!()`.