### PR TITLE
Bump rusqlite version to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "tests/test.rs"
 
 [dependencies]
 r2d2 = "0.8"
-rusqlite = "0.14.0"
+rusqlite = "0.15"
 
 [dev-dependencies]
 tempdir = "0.3"


### PR DESCRIPTION
Since rusqlite 0.15.0 introduces breaking changes, this will probably require a new minor version of this library to 0.7.0, as per #19.