### PR TITLE
bump rusqlite version to 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "tests/test.rs"
 
 [dependencies]
 r2d2 = "0.8"
-rusqlite = "0.15"
+rusqlite = "0.16"
 
 [dev-dependencies]
 tempdir = "0.3"


### PR DESCRIPTION
Please release a version with sqlite bumped to 0.16.

0.16 picks up a security fix in the bundled sqlite, which I am using, and care about.