### PR TITLE
Bump version of rusqlite to 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "tests/test.rs"
 
 [dependencies]
 r2d2 = "0.8"
-rusqlite = "0.20"
+rusqlite = "0.21"
 
 [dev-dependencies]
 tempdir = "0.3"


### PR DESCRIPTION
`rusqlite` 0.21 is out.