### PR TITLE
make `with_init` closure recieve `&mut Connection`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ rusqlite = "0.21"
 
 [dev-dependencies]
 tempdir = "0.3"
+
+[dev-dependencies.rusqlite]
+features = ["trace"]


### PR DESCRIPTION
Some methods on `Connection` require a mutable reference, like [`trace`](https://docs.rs/rusqlite/0.21.0/rusqlite/struct.Connection.html#method.trace).