### PR TITLE
Bump rusqlite to 0.22 and fix Cargo deprecation warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,11 @@ path = "tests/test.rs"
 
 [dependencies]
 r2d2 = "0.8"
-rusqlite = "0.21"
+rusqlite = "0.22"
 
 [dev-dependencies]
 tempdir = "0.3"
 
 [dev-dependencies.rusqlite]
+version = "0.22"
 features = ["trace"]


### PR DESCRIPTION
When running `cargo test`, cargo complained with:

```
$ cargo test
warning: dependency (rusqlite) specified without providing a local path, Git repository, or version to use. This will be considered an error in future versions
```

I have fixed that in this patch as well.