### PR TITLE
Add bundled feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ name = "r2d2_sqlite"
 path = "src/lib.rs"
 test = false
 
+[features]
+bundled = [ "rusqlite/bundled" ]
+
 [[test]]
 name = "test"
 path = "tests/test.rs"


### PR DESCRIPTION
 Hello, I believe bundled is a common enough feature for sqlite that it should be included as part of the re-export, if you want to keep the feature set clean I understand, just thought it was common enough.

 Thanks