### PR TITLE
add preliminary sqlcipher support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,23 @@ test = false
 name = "test"
 path = "tests/test.rs"
 
+
+
 [dependencies]
 r2d2 = "0.8"
-rusqlite = "0.25"
+
+[dependencies.rusqlite]
+version = "0.25"
+git = "https://github.com/rusqlite/rusqlite"
 
 [dev-dependencies]
 tempdir = "0.3"
 
 [dev-dependencies.rusqlite]
 version = "0.25"
+git = "https://github.com/rusqlite/rusqlite"
 features = ["trace"]
+
+
+[features]
+bundled-sqlcipher = ["rusqlite/bundled-sqlcipher"]


### PR DESCRIPTION
rusqlite will come with sqlcipher support. I have made a temporary way to use this with sqlcipher. Do not merge with main right now.