### PR TITLE
chore: expose rusqlite vendored openssl feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,6 @@ features = ["trace"]
 [features]
 bundled = ["rusqlite/bundled"]
 bundled-sqlcipher = ["rusqlite/bundled-sqlcipher"]
+bundled-sqlcipher-vendored-openssl = [
+  "rusqlite/bundled-sqlcipher-vendored-openssl",
+]


### PR DESCRIPTION
As suggested in #61, here's a PR to expose the feature of a vendored openssl from the rusqlite crate. Please let me know if you want to have an `Unreleased` section in the changelog with this change.

closes #61